### PR TITLE
Test integration testsuite fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 dist
 types
 .conf*
+.pnpm-store

--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
     "release": "pnpm test && standard-version && git push --follow-tags && pnpm publish"
   },
   "peerDependencies": {
-    "@apollo/server": "^4.0.1",
+    "@apollo/server": "https://pkg.csb.dev/apollographql/apollo-server/commit/12bf6ac7/@apollo/server",
     "h3": "^0.8.3"
   },
   "devDependencies": {
-    "@apollo/server": "^4.0.1",
-    "@apollo/server-integration-testsuite": "^4.0.1",
+    "@apollo/server": "https://pkg.csb.dev/apollographql/apollo-server/commit/12bf6ac7/@apollo/server",
+    "@apollo/server-integration-testsuite": "https://pkg.csb.dev/apollographql/apollo-server/commit/12bf6ac7/@apollo/server-integration-testsuite",
     "@apollo/utils.withrequired": "^1.0.1",
     "@jest/globals": "^29.2.0",
     "@nuxtjs/eslint-config-typescript": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,8 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@apollo/server': ^4.0.1
-  '@apollo/server-integration-testsuite': ^4.0.1
+  '@apollo/server': https://pkg.csb.dev/apollographql/apollo-server/commit/12bf6ac7/@apollo/server
+  '@apollo/server-integration-testsuite': https://pkg.csb.dev/apollographql/apollo-server/commit/12bf6ac7/@apollo/server-integration-testsuite
   '@apollo/utils.withrequired': ^1.0.1
   '@jest/globals': ^29.2.0
   '@nuxtjs/eslint-config-typescript': ^11.0.0
@@ -23,8 +23,8 @@ specifiers:
   vitest: ^0.24.3
 
 devDependencies:
-  '@apollo/server': 4.0.1_graphql@16.6.0
-  '@apollo/server-integration-testsuite': 4.0.1_3p4xxrnsmhizuyl6xemrou6ula
+  '@apollo/server': '@pkg.csb.dev/apollographql/apollo-server/commit/12bf6ac7/@apollo/server_graphql@16.6.0'
+  '@apollo/server-integration-testsuite': '@pkg.csb.dev/apollographql/apollo-server/commit/12bf6ac7/@apollo/server-integration-testsuite_3p4xxrnsmhizuyl6xemrou6ula'
   '@apollo/utils.withrequired': 1.0.1
   '@jest/globals': 29.2.0
   '@nuxtjs/eslint-config-typescript': 11.0.0_z4bbprzjrhnsfa24uvmcbu7f5q
@@ -123,45 +123,10 @@ packages:
       graphql: 14.x || 15.x || 16.x
     dependencies:
       '@apollo/usage-reporting-protobuf': 4.0.0
-      '@apollo/utils.fetcher': 1.1.0
+      '@apollo/utils.fetcher': 1.1.1
       '@apollo/utils.keyvaluecache': 1.0.1
-      '@apollo/utils.logger': 1.0.0
+      '@apollo/utils.logger': 1.0.1
       graphql: 16.6.0
-    dev: true
-
-  /@apollo/server-integration-testsuite/4.0.1_3p4xxrnsmhizuyl6xemrou6ula:
-    resolution: {integrity: sha512-BslUtXqKy9Lipk+qhgNZd7c3x6sJ9Hit3SOPy0mZu5SAOSrPnUGjw9lXUWI5hq9psryHeyIH7VNUAmkiwfDDcg==}
-    engines: {node: '>=14.16.0'}
-    peerDependencies:
-      '@apollo/server': ^4.0.1
-      '@jest/globals': 28.x || 29.x
-      graphql: ^16.6.0
-      jest: 28.x || 29.x
-    dependencies:
-      '@apollo/cache-control-types': 1.0.2_graphql@16.6.0
-      '@apollo/client': 3.7.0_graphql@16.6.0
-      '@apollo/server': 4.0.1_graphql@16.6.0
-      '@apollo/server-plugin-landing-page-graphql-playground': 4.0.0_@apollo+server@4.0.1
-      '@apollo/usage-reporting-protobuf': 4.0.0
-      '@apollo/utils.createhash': 1.1.0
-      '@apollo/utils.keyvaluecache': 1.0.1
-      '@jest/globals': 29.2.0
-      '@josephg/resolvable': 1.0.1
-      body-parser: 1.20.1
-      express: 4.18.2
-      graphql: 16.6.0
-      graphql-tag: 2.12.6_graphql@16.6.0
-      jest: 29.2.0
-      loglevel: 1.8.0
-      node-fetch: 2.6.7
-      supertest: 6.3.0
-    transitivePeerDependencies:
-      - encoding
-      - graphql-ws
-      - react
-      - react-dom
-      - subscriptions-transport-ws
-      - supports-color
     dev: true
 
   /@apollo/server-plugin-landing-page-graphql-playground/4.0.0_@apollo+server@4.0.1:
@@ -170,45 +135,8 @@ packages:
     peerDependencies:
       '@apollo/server': ^4.0.0
     dependencies:
-      '@apollo/server': 4.0.1_graphql@16.6.0
+      '@apollo/server': '@pkg.csb.dev/apollographql/apollo-server/commit/12bf6ac7/@apollo/server_graphql@16.6.0'
       '@apollographql/graphql-playground-html': 1.6.29
-    dev: true
-
-  /@apollo/server/4.0.1_graphql@16.6.0:
-    resolution: {integrity: sha512-Ggwh15ukRyKHLdzRzy0138AgnD16aYC9J6tvK1GLzFn7vgHJjwCAOPuNVdni8/qRV3nbZvI0Z1ieYXYaF3lwXQ==}
-    engines: {node: '>=14.16.0'}
-    peerDependencies:
-      graphql: ^16.6.0
-    dependencies:
-      '@apollo/cache-control-types': 1.0.2_graphql@16.6.0
-      '@apollo/server-gateway-interface': 1.0.4_graphql@16.6.0
-      '@apollo/usage-reporting-protobuf': 4.0.0
-      '@apollo/utils.createhash': 1.1.0
-      '@apollo/utils.fetcher': 1.1.0
-      '@apollo/utils.isnodelike': 1.1.0
-      '@apollo/utils.keyvaluecache': 1.0.1
-      '@apollo/utils.logger': 1.0.0
-      '@apollo/utils.usagereporting': 1.0.0_graphql@16.6.0
-      '@apollo/utils.withrequired': 1.0.1
-      '@graphql-tools/schema': 9.0.4_graphql@16.6.0
-      '@josephg/resolvable': 1.0.1
-      '@types/express': 4.17.14
-      '@types/express-serve-static-core': 4.17.31
-      '@types/node-fetch': 2.6.2
-      async-retry: 1.3.3
-      body-parser: 1.20.1
-      cors: 2.8.5
-      express: 4.18.2
-      graphql: 16.6.0
-      loglevel: 1.8.0
-      lru-cache: 7.14.0
-      negotiator: 0.6.3
-      node-fetch: 2.6.7
-      uuid: 9.0.0
-      whatwg-mimetype: 3.0.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
     dev: true
 
   /@apollo/usage-reporting-protobuf/4.0.0:
@@ -234,8 +162,8 @@ packages:
       graphql: 16.6.0
     dev: true
 
-  /@apollo/utils.fetcher/1.1.0:
-    resolution: {integrity: sha512-UOI25Q8kN6ADYxCPSzilMzMir2CNNFLif/+1WcTgMog9HbMGtG3LSlC9vStsSBcNGlwViaFFGP4ybgoZ2Ro5rQ==}
+  /@apollo/utils.fetcher/1.1.1:
+    resolution: {integrity: sha512-0vXVznO7kw5VWwxyV5wsDvYEwjDpyZ7vYQAXCseLXqBn2eWEIDViM7qRzi/Hnv4zzAQ05phdimSED99K+lg+SQ==}
     dev: true
 
   /@apollo/utils.isnodelike/1.1.0:
@@ -246,12 +174,12 @@ packages:
   /@apollo/utils.keyvaluecache/1.0.1:
     resolution: {integrity: sha512-nLgYLomqjVimEzQ4cdvVQkcryi970NDvcRVPfd0OPeXhBfda38WjBq+WhQFk+czSHrmrSp34YHBxpat0EtiowA==}
     dependencies:
-      '@apollo/utils.logger': 1.0.0
+      '@apollo/utils.logger': 1.0.1
       lru-cache: 7.14.0
     dev: true
 
-  /@apollo/utils.logger/1.0.0:
-    resolution: {integrity: sha512-dx9XrjyisD2pOa+KsB5RcDbWIAdgC91gJfeyLCgy0ctJMjQe7yZK5kdWaWlaOoCeX0z6YI9iYlg7vMPyMpQF3Q==}
+  /@apollo/utils.logger/1.0.1:
+    resolution: {integrity: sha512-XdlzoY7fYNK4OIcvMD2G94RoFZbzTQaNP0jozmqqMudmaGo2I/2Jx71xlDJ801mWA/mbYRihyaw6KJii7k5RVA==}
     dev: true
 
   /@apollo/utils.printwithreducedwhitespace/1.1.0_graphql@16.6.0:
@@ -6760,4 +6688,90 @@ packages:
 
   /zen-observable/0.8.15:
     resolution: {integrity: sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==}
+    dev: true
+
+  '@pkg.csb.dev/apollographql/apollo-server/commit/12bf6ac7/@apollo/server-integration-testsuite_3p4xxrnsmhizuyl6xemrou6ula':
+    resolution: {tarball: https://pkg.csb.dev/apollographql/apollo-server/commit/12bf6ac7/@apollo/server-integration-testsuite}
+    id: '@pkg.csb.dev/apollographql/apollo-server/commit/12bf6ac7/@apollo/server-integration-testsuite'
+    name: '@apollo/server-integration-testsuite'
+    version: 4.0.1
+    engines: {node: '>=14.16.0'}
+    peerDependencies:
+      '@apollo/server': ^4.0.1
+      '@jest/globals': 28.x || 29.x
+      graphql: ^16.6.0
+      jest: 28.x || 29.x
+    dependencies:
+      '@apollo/cache-control-types': 1.0.2_graphql@16.6.0
+      '@apollo/client': 3.7.0_graphql@16.6.0
+      '@apollo/server': '@pkg.csb.dev/apollographql/apollo-server/commit/12bf6ac7/@apollo/server_graphql@16.6.0'
+      '@apollo/server-plugin-landing-page-graphql-playground': 4.0.0_@apollo+server@4.0.1
+      '@apollo/usage-reporting-protobuf': '@pkg.csb.dev/apollographql/apollo-server/commit/12bf6ac7/@apollo/usage-reporting-protobuf'
+      '@apollo/utils.createhash': 1.1.0
+      '@apollo/utils.keyvaluecache': 1.0.1
+      '@jest/globals': 29.2.0
+      '@josephg/resolvable': 1.0.1
+      body-parser: 1.20.1
+      express: 4.18.2
+      graphql: 16.6.0
+      graphql-tag: 2.12.6_graphql@16.6.0
+      jest: 29.2.0
+      loglevel: 1.8.0
+      node-fetch: 2.6.7
+      supertest: 6.3.0
+    transitivePeerDependencies:
+      - encoding
+      - graphql-ws
+      - react
+      - react-dom
+      - subscriptions-transport-ws
+      - supports-color
+    dev: true
+
+  '@pkg.csb.dev/apollographql/apollo-server/commit/12bf6ac7/@apollo/server_graphql@16.6.0':
+    resolution: {tarball: https://pkg.csb.dev/apollographql/apollo-server/commit/12bf6ac7/@apollo/server}
+    id: '@pkg.csb.dev/apollographql/apollo-server/commit/12bf6ac7/@apollo/server'
+    name: '@apollo/server'
+    version: 4.0.1
+    engines: {node: '>=14.16.0'}
+    peerDependencies:
+      graphql: ^16.6.0
+    dependencies:
+      '@apollo/cache-control-types': 1.0.2_graphql@16.6.0
+      '@apollo/server-gateway-interface': 1.0.4_graphql@16.6.0
+      '@apollo/usage-reporting-protobuf': '@pkg.csb.dev/apollographql/apollo-server/commit/12bf6ac7/@apollo/usage-reporting-protobuf'
+      '@apollo/utils.createhash': 1.1.0
+      '@apollo/utils.fetcher': 1.1.1
+      '@apollo/utils.isnodelike': 1.1.0
+      '@apollo/utils.keyvaluecache': 1.0.1
+      '@apollo/utils.logger': 1.0.1
+      '@apollo/utils.usagereporting': 1.0.0_graphql@16.6.0
+      '@apollo/utils.withrequired': 1.0.1
+      '@graphql-tools/schema': 9.0.4_graphql@16.6.0
+      '@josephg/resolvable': 1.0.1
+      '@types/express': 4.17.14
+      '@types/express-serve-static-core': 4.17.31
+      '@types/node-fetch': 2.6.2
+      async-retry: 1.3.3
+      body-parser: 1.20.1
+      cors: 2.8.5
+      express: 4.18.2
+      graphql: 16.6.0
+      loglevel: 1.8.0
+      lru-cache: 7.14.0
+      negotiator: 0.6.3
+      node-fetch: 2.6.7
+      uuid: 9.0.0
+      whatwg-mimetype: 3.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true
+
+  '@pkg.csb.dev/apollographql/apollo-server/commit/12bf6ac7/@apollo/usage-reporting-protobuf':
+    resolution: {tarball: https://pkg.csb.dev/apollographql/apollo-server/commit/12bf6ac7/@apollo/usage-reporting-protobuf}
+    name: '@apollo/usage-reporting-protobuf'
+    version: 4.0.0
+    dependencies:
+      '@apollo/protobufjs': 1.2.6
     dev: true


### PR DESCRIPTION
Testing builds from https://github.com/apollographql/apollo-server/pull/7055.

This demonstrates the new error:
`Do not import `@jest/globals` outside of the Jest test environment`

It seems like there's maybe an underlying difference in `ts-jest` (what we use in most of our packages where this is currently working) vs. `vitest` in that `@jest/globals` is actually being required in the testsuite's lib code when it shouldn't be.

Validated this change doesn't break anything in the koa repo which uses `ts-jest`:
https://github.com/apollo-server-integrations/apollo-server-integration-koa/pull/32